### PR TITLE
Cope with multiple empty lines

### DIFF
--- a/germaner/src/main/java/de/tu/darmstadt/lt/ner/reader/NERReader.java
+++ b/germaner/src/main/java/de/tu/darmstadt/lt/ner/reader/NERReader.java
@@ -124,6 +124,7 @@ public class NERReader
                     }
                     positionIndex = 0;
                 }
+                sentence = null;
                 // init new sentence with the next recognized token
                 initSentence = true;
                 sentenceSb = new StringBuffer();


### PR DESCRIPTION
setting sentence to null prevents the sentence from being inserted multiple times when there are multiple empty lines instead of just one.
